### PR TITLE
feat: v0.3.0 - encrypted keystore, npm publish, integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,28 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly: Monday 06:00 UTC
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:integration
+        env:
+          REPUBLIC_INTEGRATION: '1'
+          REPUBLIC_TEST_KEY: ${{ secrets.REPUBLIC_TEST_KEY }}
+          REPUBLIC_TEST_ADDRESS: ${{ secrets.REPUBLIC_TEST_ADDRESS }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build
+
+      - name: Verify dist outputs
+        run: |
+          test -f dist/index.js
+          test -f dist/index.cjs
+          test -f dist/index.d.ts
+          test -f dist/cli.cjs
+
+      - name: Dry run publish
+        run: npm publish --dry-run
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-03-04
+
+### Added
+- Encrypted keystore with AES-256-GCM + scrypt KDF (N=16384, r=8, p=1)
+- Password prompt on key create/import/export/sign operations
+- Automatic legacy plaintext keystore detection
+- `keys migrate` CLI command for plaintext-to-encrypted migration
+- `--no-password` flag and `REPUBLIC_SDK_PASSWORD` env var for CI/automation
+- `KeystoreError` error class for keystore operations
+- `EncryptedKey`, `KeyStoreV2`, `ScryptParams` types
+- npm publish workflow (GitHub Releases → npm with provenance)
+- Live chain integration tests (manual + weekly Monday schedule)
+- `test:integration` npm script
+
+### Changed
+- Key storage format upgraded to v2 (encrypted by default)
+- CLI signing commands now prompt for password to decrypt keys
+- npm version badge added to README
+
+### Security
+- Private keys now encrypted at rest with AES-256-GCM
+- scrypt KDF for password-based key derivation
+- GCM authentication tag prevents ciphertext tampering
+
 ## [0.2.1] - 2026-03-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-04
+
+### Changed
+- Branch protection tightened: require 1 approving review, CODEOWNERS review required, stale review dismissal enabled
+
 ## [0.2.0] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Republic SDK
 
+[![npm version](https://img.shields.io/npm/v/republic-sdk.svg)](https://www.npmjs.com/package/republic-sdk)
 [![CI](https://github.com/eren-karakus0/republic-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/eren-karakus0/republic-sdk/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg)](https://nodejs.org)
@@ -11,6 +12,7 @@ Republic AI is a Cosmos SDK-based blockchain with EVM compatibility (ethsecp256k
 ## Features
 
 - **Key Management** — Generate, import, export secp256k1 keys with ethsecp256k1 address derivation
+- **Encrypted Keystore** — AES-256-GCM encryption with scrypt KDF for private keys at rest
 - **RPC Client** — Query node status, account info, balances with automatic retry & exponential backoff
 - **Staking Queries** — Validators, delegations, rewards
 - **Governance** — Query proposals, submit votes
@@ -22,21 +24,15 @@ Republic AI is a Cosmos SDK-based blockchain with EVM compatibility (ethsecp256k
 
 ## Installation
 
-Install directly from GitHub:
+```bash
+npm install republic-sdk
+```
+
+Or install directly from GitHub:
 
 ```bash
 npm install github:eren-karakus0/republic-sdk
 ```
-
-Or clone and build from source:
-
-```bash
-git clone https://github.com/eren-karakus0/republic-sdk.git
-cd republic-sdk
-npm install && npm run build
-```
-
-<!-- TODO: npm install republic-sdk (after npm publish) -->
 
 ## Quick Start
 
@@ -283,6 +279,7 @@ republic-sdk status <job-id> --watch
 | `TimeoutError` | Polling/wait timeouts |
 | `ValidationError` | Input validation errors |
 | `AccountNotFoundError` | Account 404 (address) |
+| `KeystoreError` | Keystore encrypt/decrypt errors |
 
 ## Chain Configuration
 
@@ -302,7 +299,7 @@ republic-sdk status <job-id> --watch
 ```bash
 npm install       # Install dependencies
 npm run lint      # Lint (src, bin, tests)
-npm run test      # Run 105 tests
+npm run test      # Run 132 tests
 npm run build     # Build ESM + CJS + DTS
 npm run dev       # Watch mode
 ```

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { RepublicKey } from '../src/key.js';
@@ -8,7 +8,16 @@ import { JobManager } from '../src/job.js';
 import { signTx, msgSend, msgDelegate, msgWithdrawReward, msgVote } from '../src/transaction.js';
 import { araiToRai } from '../src/utils.js';
 import { REPUBLIC_TESTNET, DEFAULT_GAS_LIMIT, DEFAULT_FEE_AMOUNT } from '../src/constants.js';
-import type { KeyStore } from '../src/types.js';
+import {
+  encryptPrivateKey,
+  decryptPrivateKey,
+  isLegacyKeyStore,
+  migrateLegacyStore,
+  loadKeyStore,
+  saveKeyStore,
+  promptPassword,
+} from '../src/keystore.js';
+import type { KeyStoreV2, LegacyKeyStore, EncryptedKey } from '../src/types.js';
 
 const CONFIG_DIR = join(homedir(), '.republic-sdk');
 const KEYS_FILE = join(CONFIG_DIR, 'keys.json');
@@ -19,30 +28,94 @@ function ensureConfigDir(): void {
   }
 }
 
-function loadKeys(): KeyStore {
-  if (!existsSync(KEYS_FILE)) return {};
-  const raw = readFileSync(KEYS_FILE, 'utf-8');
-  return JSON.parse(raw) as KeyStore;
+function getPasswordFromEnv(): string | null {
+  return process.env.REPUBLIC_SDK_PASSWORD ?? null;
 }
 
-function saveKeys(store: KeyStore): void {
-  ensureConfigDir();
-  writeFileSync(KEYS_FILE, JSON.stringify(store, null, 2), 'utf-8');
-  try {
-    chmodSync(KEYS_FILE, 0o600);
-  } catch {
-    // chmod may not work on Windows
+async function getPassword(message = 'Enter password: ', opts?: { noPassword?: boolean }): Promise<string> {
+  if (opts?.noPassword) {
+    return '';
   }
+
+  const envPassword = getPasswordFromEnv();
+  if (envPassword) {
+    return envPassword;
+  }
+
+  return promptPassword(message);
 }
 
-function getKey(name: string): RepublicKey {
-  const store = loadKeys();
-  const entry = store[name];
-  if (!entry) {
+function loadKeysV2(): KeyStoreV2 {
+  const data = loadKeyStore(KEYS_FILE);
+  if (data === null) {
+    return { version: 2, keys: {} };
+  }
+
+  if (isLegacyKeyStore(data)) {
+    // Return as-is but wrapped - migration needs password so can't do it here
+    // Callers should check and migrate when needed
+    return { version: 2, keys: {} };
+  }
+
+  return data;
+}
+
+function hasLegacyKeys(): boolean {
+  const data = loadKeyStore(KEYS_FILE);
+  return data !== null && isLegacyKeyStore(data);
+}
+
+function loadLegacyKeys(): LegacyKeyStore {
+  const data = loadKeyStore(KEYS_FILE);
+  if (data !== null && isLegacyKeyStore(data)) {
+    return data;
+  }
+  return {};
+}
+
+async function getDecryptedKey(name: string, opts?: { noPassword?: boolean }): Promise<RepublicKey> {
+  if (opts?.noPassword) {
+    // In no-password mode, check legacy store first
+    const data = loadKeyStore(KEYS_FILE);
+    if (data !== null && isLegacyKeyStore(data)) {
+      const entry = data[name];
+      if (!entry) {
+        console.error(`Key "${name}" not found. Use 'keys list' to see available keys.`);
+        process.exit(1);
+      }
+      return RepublicKey.fromPrivateKey(entry.privateKey);
+    }
+    console.error('--no-password requires plaintext keystore. Use "keys migrate" to migrate or remove --no-password flag.');
+    process.exit(1);
+  }
+
+  const data = loadKeyStore(KEYS_FILE);
+
+  // Legacy store: prompt for migration
+  if (data !== null && isLegacyKeyStore(data)) {
+    console.error('Legacy plaintext keystore detected. Run "republic-sdk keys migrate" to encrypt your keys.');
+    const entry = data[name];
+    if (!entry) {
+      console.error(`Key "${name}" not found.`);
+      process.exit(1);
+    }
+    return RepublicKey.fromPrivateKey(entry.privateKey);
+  }
+
+  const store = data as KeyStoreV2 | null;
+  if (!store || !store.keys[name]) {
     console.error(`Key "${name}" not found. Use 'keys list' to see available keys.`);
     process.exit(1);
   }
-  return RepublicKey.fromPrivateKey(entry.privateKey);
+
+  const password = await getPassword('Enter password to unlock key: ');
+  try {
+    const privateKeyHex = decryptPrivateKey(store.keys[name].crypto, password);
+    return RepublicKey.fromPrivateKey(privateKeyHex);
+  } catch (err) {
+    console.error('Failed to decrypt key:', (err as Error).message);
+    process.exit(1);
+  }
 }
 
 function parsePositiveInt(value: string, label: string, min = 1): number {
@@ -68,9 +141,40 @@ const keys = program.command('keys').description('Key management');
 keys
   .command('create <name>')
   .description('Create a new key pair')
-  .action((name: string) => {
-    const store = loadKeys();
-    if (store[name]) {
+  .option('--no-password', 'Store key without encryption (not recommended)')
+  .action(async (name: string, opts: { noPassword?: boolean }) => {
+    if (opts.noPassword) {
+      console.warn('WARNING: Storing key without encryption. Use only for testing/CI.');
+    }
+
+    // Check for legacy store
+    if (hasLegacyKeys()) {
+      const legacy = loadLegacyKeys();
+      if (legacy[name]) {
+        console.error(`Key "${name}" already exists.`);
+        process.exit(1);
+      }
+
+      if (opts.noPassword) {
+        const key = RepublicKey.generate();
+        legacy[name] = {
+          privateKey: key.privateKey,
+          address: key.getAddress(),
+          publicKey: key.publicKey,
+        };
+        ensureConfigDir();
+        const { writeFileSync, chmodSync } = await import('fs');
+        writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
+        try { chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
+        console.log(`Key created: ${name}`);
+        console.log(`Address:     ${key.getAddress()}`);
+        console.log(`Public Key:  ${key.publicKey}`);
+        return;
+      }
+    }
+
+    const store = loadKeysV2();
+    if (store.keys[name]) {
       console.error(`Key "${name}" already exists.`);
       process.exit(1);
     }
@@ -78,12 +182,38 @@ keys
     const key = RepublicKey.generate();
     const address = key.getAddress();
 
-    store[name] = {
-      privateKey: key.privateKey,
-      address,
-      publicKey: key.publicKey,
-    };
-    saveKeys(store);
+    if (opts.noPassword) {
+      // Store in legacy format for no-password mode
+      const legacy = loadLegacyKeys();
+      legacy[name] = {
+        privateKey: key.privateKey,
+        address,
+        publicKey: key.publicKey,
+      };
+      ensureConfigDir();
+      const { writeFileSync, chmodSync } = await import('fs');
+      writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
+      try { chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
+    } else {
+      const password = await getPassword('Create password for key: ');
+      const confirmPassword = await getPassword('Confirm password: ');
+      if (password !== confirmPassword) {
+        console.error('Passwords do not match.');
+        process.exit(1);
+      }
+
+      const encrypted: EncryptedKey = {
+        version: 1,
+        name,
+        address,
+        publicKey: key.publicKey,
+        crypto: encryptPrivateKey(key.privateKey, password),
+      };
+
+      store.keys[name] = encrypted;
+      ensureConfigDir();
+      saveKeyStore(KEYS_FILE, store);
+    }
 
     console.log(`Key created: ${name}`);
     console.log(`Address:     ${address}`);
@@ -94,8 +224,24 @@ keys
   .command('list')
   .description('List all stored keys')
   .action(() => {
-    const store = loadKeys();
-    const names = Object.keys(store);
+    const data = loadKeyStore(KEYS_FILE);
+
+    if (data === null) {
+      console.log('No keys found.');
+      return;
+    }
+
+    let names: string[];
+    let getAddress: (name: string) => string;
+
+    if (isLegacyKeyStore(data)) {
+      names = Object.keys(data);
+      getAddress = (n) => data[n].address;
+    } else {
+      const store = data as KeyStoreV2;
+      names = Object.keys(store.keys);
+      getAddress = (n) => store.keys[n].address;
+    }
 
     if (names.length === 0) {
       console.log('No keys found.');
@@ -105,7 +251,7 @@ keys
     console.log('Name'.padEnd(20) + 'Address');
     console.log('-'.repeat(60));
     for (const name of names) {
-      console.log(name.padEnd(20) + store[name].address);
+      console.log(name.padEnd(20) + getAddress(name));
     }
   });
 
@@ -113,38 +259,91 @@ keys
   .command('show <name>')
   .description('Show key details')
   .action((name: string) => {
-    const store = loadKeys();
-    const entry = store[name];
-    if (!entry) {
+    const data = loadKeyStore(KEYS_FILE);
+
+    if (data === null) {
       console.error(`Key "${name}" not found.`);
       process.exit(1);
     }
 
-    console.log(`Name:       ${name}`);
-    console.log(`Address:    ${entry.address}`);
-    console.log(`Public Key: ${entry.publicKey}`);
+    if (isLegacyKeyStore(data)) {
+      const entry = data[name];
+      if (!entry) {
+        console.error(`Key "${name}" not found.`);
+        process.exit(1);
+      }
+      console.log(`Name:       ${name}`);
+      console.log(`Address:    ${entry.address}`);
+      console.log(`Public Key: ${entry.publicKey}`);
+      console.log(`Encrypted:  no`);
+    } else {
+      const store = data as KeyStoreV2;
+      const entry = store.keys[name];
+      if (!entry) {
+        console.error(`Key "${name}" not found.`);
+        process.exit(1);
+      }
+      console.log(`Name:       ${name}`);
+      console.log(`Address:    ${entry.address}`);
+      console.log(`Public Key: ${entry.publicKey}`);
+      console.log(`Encrypted:  yes`);
+    }
   });
 
 keys
   .command('import <name> <private-key>')
   .description('Import a key from hex private key')
-  .action((name: string, privateKeyHex: string) => {
-    const store = loadKeys();
-    if (store[name]) {
-      console.error(`Key "${name}" already exists.`);
-      process.exit(1);
+  .option('--no-password', 'Store key without encryption (not recommended)')
+  .action(async (name: string, privateKeyHex: string, opts: { noPassword?: boolean }) => {
+    if (opts.noPassword) {
+      console.warn('WARNING: Storing key without encryption. Use only for testing/CI.');
     }
 
     try {
       const key = RepublicKey.fromPrivateKey(privateKeyHex);
       const address = key.getAddress();
 
-      store[name] = {
-        privateKey: key.privateKey,
-        address,
-        publicKey: key.publicKey,
-      };
-      saveKeys(store);
+      if (opts.noPassword) {
+        const legacy = loadLegacyKeys();
+        if (legacy[name]) {
+          console.error(`Key "${name}" already exists.`);
+          process.exit(1);
+        }
+        legacy[name] = {
+          privateKey: key.privateKey,
+          address,
+          publicKey: key.publicKey,
+        };
+        ensureConfigDir();
+        const { writeFileSync, chmodSync } = await import('fs');
+        writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
+        try { chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
+      } else {
+        const store = loadKeysV2();
+        if (store.keys[name]) {
+          console.error(`Key "${name}" already exists.`);
+          process.exit(1);
+        }
+
+        const password = await getPassword('Create password for key: ');
+        const confirmPassword = await getPassword('Confirm password: ');
+        if (password !== confirmPassword) {
+          console.error('Passwords do not match.');
+          process.exit(1);
+        }
+
+        const encrypted: EncryptedKey = {
+          version: 1,
+          name,
+          address,
+          publicKey: key.publicKey,
+          crypto: encryptPrivateKey(key.privateKey, password),
+        };
+
+        store.keys[name] = encrypted;
+        ensureConfigDir();
+        saveKeyStore(KEYS_FILE, store);
+      }
 
       console.log(`Key imported: ${name}`);
       console.log(`Address:      ${address}`);
@@ -157,30 +356,110 @@ keys
 keys
   .command('export <name>')
   .description('Export private key (hex)')
-  .action((name: string) => {
-    const store = loadKeys();
-    const entry = store[name];
+  .option('--no-password', 'Skip password prompt (only works with plaintext store)')
+  .action(async (name: string, opts: { noPassword?: boolean }) => {
+    const data = loadKeyStore(KEYS_FILE);
+
+    if (data === null) {
+      console.error(`Key "${name}" not found.`);
+      process.exit(1);
+    }
+
+    if (isLegacyKeyStore(data)) {
+      const entry = data[name];
+      if (!entry) {
+        console.error(`Key "${name}" not found.`);
+        process.exit(1);
+      }
+      console.log(entry.privateKey);
+      return;
+    }
+
+    const store = data as KeyStoreV2;
+    const entry = store.keys[name];
     if (!entry) {
       console.error(`Key "${name}" not found.`);
       process.exit(1);
     }
 
-    console.log(entry.privateKey);
+    const password = await getPassword('Enter password to export key: ', opts);
+    try {
+      const privateKeyHex = decryptPrivateKey(entry.crypto, password);
+      console.log(privateKeyHex);
+    } catch (err) {
+      console.error('Failed to decrypt key:', (err as Error).message);
+      process.exit(1);
+    }
   });
 
 keys
   .command('delete <name>')
   .description('Delete a stored key')
-  .action((name: string) => {
-    const store = loadKeys();
-    if (!store[name]) {
+  .action(async (name: string) => {
+    const data = loadKeyStore(KEYS_FILE);
+
+    if (data === null) {
       console.error(`Key "${name}" not found.`);
       process.exit(1);
     }
 
-    delete store[name];
-    saveKeys(store);
+    if (isLegacyKeyStore(data)) {
+      if (!data[name]) {
+        console.error(`Key "${name}" not found.`);
+        process.exit(1);
+      }
+      delete data[name];
+      ensureConfigDir();
+      const fs = await import('fs');
+      fs.writeFileSync(KEYS_FILE, JSON.stringify(data, null, 2), 'utf-8');
+      try { fs.chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
+    } else {
+      const store = data as KeyStoreV2;
+      if (!store.keys[name]) {
+        console.error(`Key "${name}" not found.`);
+        process.exit(1);
+      }
+      delete store.keys[name];
+      saveKeyStore(KEYS_FILE, store);
+    }
+
     console.log(`Key "${name}" deleted.`);
+  });
+
+keys
+  .command('migrate')
+  .description('Migrate plaintext keys to encrypted keystore')
+  .action(async () => {
+    const data = loadKeyStore(KEYS_FILE);
+
+    if (data === null) {
+      console.log('No keystore found. Nothing to migrate.');
+      return;
+    }
+
+    if (!isLegacyKeyStore(data)) {
+      console.log('Keystore is already encrypted. Nothing to migrate.');
+      return;
+    }
+
+    const names = Object.keys(data);
+    if (names.length === 0) {
+      console.log('No keys found. Nothing to migrate.');
+      return;
+    }
+
+    console.log(`Found ${names.length} plaintext key(s): ${names.join(', ')}`);
+    const password = await getPassword('Create encryption password: ');
+    const confirmPassword = await getPassword('Confirm password: ');
+    if (password !== confirmPassword) {
+      console.error('Passwords do not match. Migration aborted.');
+      process.exit(1);
+    }
+
+    const encrypted = migrateLegacyStore(data, password);
+    ensureConfigDir();
+    saveKeyStore(KEYS_FILE, encrypted);
+    console.log(`Successfully migrated ${names.length} key(s) to encrypted keystore.`);
   });
 
 // ─── Node Status ──────────────────────────────────────────────────────────────
@@ -248,12 +527,14 @@ program
   .option('--memo <memo>', 'Transaction memo', '')
   .option('--gas <limit>', 'Gas limit', String(DEFAULT_GAS_LIMIT))
   .option('--fees <amount>', 'Fee amount in arai', DEFAULT_FEE_AMOUNT)
+  .option('--no-password', 'Skip password prompt (plaintext keys only)')
   .action(async (opts: {
     from: string; to: string; amount: string;
     rpc: string; rest: string; memo: string; gas: string; fees: string;
+    noPassword?: boolean;
   }) => {
     try {
-      const key = getKey(opts.from);
+      const key = await getDecryptedKey(opts.from, { noPassword: opts.noPassword });
       const client = new RepublicClient({ rpc: opts.rpc, rest: opts.rest });
       const address = key.getAddress();
       const accountInfo = await client.getAccountInfoSafe(address);
@@ -292,12 +573,14 @@ program
   .option('--memo <memo>', 'Transaction memo', '')
   .option('--gas <limit>', 'Gas limit', String(DEFAULT_GAS_LIMIT))
   .option('--fees <amount>', 'Fee amount in arai', DEFAULT_FEE_AMOUNT)
+  .option('--no-password', 'Skip password prompt (plaintext keys only)')
   .action(async (opts: {
     from: string; validator: string; amount: string;
     rpc: string; rest: string; memo: string; gas: string; fees: string;
+    noPassword?: boolean;
   }) => {
     try {
-      const key = getKey(opts.from);
+      const key = await getDecryptedKey(opts.from, { noPassword: opts.noPassword });
       const client = new RepublicClient({ rpc: opts.rpc, rest: opts.rest });
       const address = key.getAddress();
       const accountInfo = await client.getAccountInfoSafe(address);
@@ -436,12 +719,14 @@ program
   .option('--memo <memo>', 'Transaction memo', '')
   .option('--gas <limit>', 'Gas limit', String(DEFAULT_GAS_LIMIT))
   .option('--fees <amount>', 'Fee amount in arai', DEFAULT_FEE_AMOUNT)
+  .option('--no-password', 'Skip password prompt (plaintext keys only)')
   .action(async (opts: {
     from: string; validator: string;
     rpc: string; rest: string; memo: string; gas: string; fees: string;
+    noPassword?: boolean;
   }) => {
     try {
-      const key = getKey(opts.from);
+      const key = await getDecryptedKey(opts.from, { noPassword: opts.noPassword });
       const client = new RepublicClient({ rpc: opts.rpc, rest: opts.rest });
       const address = key.getAddress();
       const accountInfo = await client.getAccountInfoSafe(address);
@@ -478,9 +763,11 @@ program
   .option('--memo <memo>', 'Transaction memo', '')
   .option('--gas <limit>', 'Gas limit', String(DEFAULT_GAS_LIMIT))
   .option('--fees <amount>', 'Fee amount in arai', DEFAULT_FEE_AMOUNT)
+  .option('--no-password', 'Skip password prompt (plaintext keys only)')
   .action(async (opts: {
     from: string; proposal: string; option: string;
     rpc: string; rest: string; memo: string; gas: string; fees: string;
+    noPassword?: boolean;
   }) => {
     try {
       const proposalId = parsePositiveInt(opts.proposal, 'proposal ID');
@@ -495,7 +782,7 @@ program
         process.exit(1);
       }
 
-      const key = getKey(opts.from);
+      const key = await getDecryptedKey(opts.from, { noPassword: opts.noPassword });
       const client = new RepublicClient({ rpc: opts.rpc, rest: opts.rest });
       const address = key.getAddress();
       const accountInfo = await client.getAccountInfoSafe(address);
@@ -536,14 +823,16 @@ program
   .option('--gas <limit>', 'Gas limit', String(DEFAULT_GAS_LIMIT))
   .option('--fees <amount>', 'Fee amount in arai', DEFAULT_FEE_AMOUNT)
   .option('--wait', 'Wait for job to be included in block', false)
+  .option('--no-password', 'Skip password prompt (plaintext keys only)')
   .action(async (opts: {
     from: string; validator: string; image: string;
     verification: string; uploadEndpoint: string; fetchEndpoint: string;
     feeAmount: string; rpc: string; rest: string;
     gas: string; fees: string; wait: boolean;
+    noPassword?: boolean;
   }) => {
     try {
-      const key = getKey(opts.from);
+      const key = await getDecryptedKey(opts.from, { noPassword: opts.noPassword });
       const client = new RepublicClient({ rpc: opts.rpc, rest: opts.rest });
       const jobManager = new JobManager(client, key);
       const gasLimit = parsePositiveInt(opts.gas, 'gas limit');

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -132,7 +132,7 @@ const program = new Command();
 program
   .name('republic-sdk')
   .description('CLI for Republic AI blockchain')
-  .version('0.2.0');
+  .version('0.3.0');
 
 // ─── Keys ─────────────────────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "republic-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript SDK for Republic AI blockchain - key management, transaction signing, job submission & CLI",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
     "type": "git",
     "url": "https://github.com/eren-karakus0/republic-sdk"
   },
+  "homepage": "https://github.com/eren-karakus0/republic-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/eren-karakus0/republic-sdk/issues"
+  },
   "dependencies": {
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run tests/integration.test.ts --timeout 60000",
     "lint": "eslint src/ bin/ tests/",
     "prepublishOnly": "npm run build"
   },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -59,3 +59,10 @@ export class AccountNotFoundError extends RepublicError {
     this.name = 'AccountNotFoundError';
   }
 }
+
+export class KeystoreError extends RepublicError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KeystoreError';
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,16 @@ export {
   TimeoutError,
   ValidationError,
   AccountNotFoundError,
+  KeystoreError,
 } from './errors.js';
+
+// Keystore
+export {
+  encryptPrivateKey,
+  decryptPrivateKey,
+  migrateLegacyStore,
+  isLegacyKeyStore,
+} from './keystore.js';
 
 // Utilities
 export { sleep, retry, araiToRai, raiToArai } from './utils.js';
@@ -75,4 +84,8 @@ export type {
   JobStatus,
   KeyInfo,
   KeyStore,
+  LegacyKeyStore,
+  EncryptedKey,
+  KeyStoreV2,
+  ScryptParams,
 } from './types.js';

--- a/src/keystore.ts
+++ b/src/keystore.ts
@@ -1,0 +1,192 @@
+import { scryptSync, randomBytes, createCipheriv, createDecipheriv } from 'crypto';
+import { readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
+import { createInterface } from 'readline';
+import type { EncryptedKey, KeyStoreV2, LegacyKeyStore, ScryptParams } from './types.js';
+import { KeystoreError } from './errors.js';
+
+const DEFAULT_SCRYPT_PARAMS: ScryptParams = {
+  n: 16384,
+  r: 8,
+  p: 1,
+  dklen: 32,
+};
+
+export function deriveKey(
+  password: string,
+  salt: Buffer,
+  params: ScryptParams = DEFAULT_SCRYPT_PARAMS,
+): Buffer {
+  return scryptSync(password, salt, params.dklen, {
+    N: params.n,
+    r: params.r,
+    p: params.p,
+  });
+}
+
+export function encrypt(plaintext: Buffer, key: Buffer): { ciphertext: Buffer; iv: Buffer; tag: Buffer } {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return { ciphertext: encrypted, iv, tag };
+}
+
+export function decrypt(ciphertext: Buffer, key: Buffer, iv: Buffer, tag: Buffer): Buffer {
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  try {
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch {
+    throw new KeystoreError('Decryption failed: wrong password or corrupted data');
+  }
+}
+
+export function encryptPrivateKey(
+  privateKeyHex: string,
+  password: string,
+): EncryptedKey['crypto'] {
+  if (!password) {
+    throw new KeystoreError('Password cannot be empty');
+  }
+
+  const salt = randomBytes(32);
+  const params = { ...DEFAULT_SCRYPT_PARAMS };
+  const derivedKey = deriveKey(password, salt, params);
+  const plaintext = Buffer.from(privateKeyHex, 'hex');
+  const { ciphertext, iv, tag } = encrypt(plaintext, derivedKey);
+
+  return {
+    cipher: 'aes-256-gcm',
+    ciphertext: ciphertext.toString('hex'),
+    cipherparams: {
+      iv: iv.toString('hex'),
+      tag: tag.toString('hex'),
+    },
+    kdf: 'scrypt',
+    kdfparams: {
+      ...params,
+      salt: salt.toString('hex'),
+    },
+  };
+}
+
+export function decryptPrivateKey(
+  crypto: EncryptedKey['crypto'],
+  password: string,
+): string {
+  if (!password) {
+    throw new KeystoreError('Password cannot be empty');
+  }
+
+  const salt = Buffer.from(crypto.kdfparams.salt, 'hex');
+  const derivedKey = deriveKey(password, salt, {
+    n: crypto.kdfparams.n,
+    r: crypto.kdfparams.r,
+    p: crypto.kdfparams.p,
+    dklen: crypto.kdfparams.dklen,
+  });
+
+  const ciphertext = Buffer.from(crypto.ciphertext, 'hex');
+  const iv = Buffer.from(crypto.cipherparams.iv, 'hex');
+  const tag = Buffer.from(crypto.cipherparams.tag, 'hex');
+
+  const decrypted = decrypt(ciphertext, derivedKey, iv, tag);
+  return decrypted.toString('hex');
+}
+
+export function isLegacyKeyStore(data: unknown): data is LegacyKeyStore {
+  return typeof data === 'object' && data !== null && !('version' in data);
+}
+
+export function migrateLegacyStore(legacy: LegacyKeyStore, password: string): KeyStoreV2 {
+  const keys: Record<string, EncryptedKey> = {};
+
+  for (const [name, entry] of Object.entries(legacy)) {
+    keys[name] = {
+      version: 1,
+      name,
+      address: entry.address,
+      publicKey: entry.publicKey,
+      crypto: encryptPrivateKey(entry.privateKey, password),
+    };
+  }
+
+  return { version: 2, keys };
+}
+
+export function loadKeyStore(filePath: string): KeyStoreV2 | LegacyKeyStore | null {
+  if (!existsSync(filePath)) return null;
+  const raw = readFileSync(filePath, 'utf-8');
+  const data = JSON.parse(raw) as unknown;
+
+  if (isLegacyKeyStore(data)) {
+    return data;
+  }
+
+  return data as KeyStoreV2;
+}
+
+export function saveKeyStore(filePath: string, store: KeyStoreV2): void {
+  writeFileSync(filePath, JSON.stringify(store, null, 2), 'utf-8');
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // chmod may not work on Windows
+  }
+}
+
+export async function promptPassword(message = 'Enter password: '): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stderr,
+      terminal: true,
+    });
+
+    // Attempt to hide input on terminals that support it
+    if (process.stderr.isTTY) {
+      process.stderr.write(message);
+      const stdin = process.stdin;
+      const wasRaw = stdin.isRaw;
+      if (stdin.setRawMode) {
+        stdin.setRawMode(true);
+      }
+
+      let password = '';
+      const onData = (chunk: Buffer) => {
+        const ch = chunk.toString('utf-8');
+        for (const c of ch) {
+          if (c === '\n' || c === '\r') {
+            process.stderr.write('\n');
+            stdin.removeListener('data', onData);
+            if (stdin.setRawMode) {
+              stdin.setRawMode(wasRaw ?? false);
+            }
+            rl.close();
+            resolve(password);
+            return;
+          } else if (c === '\u007F' || c === '\b') {
+            // Backspace
+            if (password.length > 0) {
+              password = password.slice(0, -1);
+            }
+          } else if (c === '\u0003') {
+            // Ctrl+C
+            process.stderr.write('\n');
+            rl.close();
+            process.exit(1);
+          } else {
+            password += c;
+          }
+        }
+      };
+      stdin.on('data', onData);
+    } else {
+      // Non-TTY fallback (piped input)
+      rl.question(message, (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+    }
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,10 +184,47 @@ export interface KeyInfo {
   publicKey: string;
 }
 
-export interface KeyStore {
+/** @deprecated Use KeyStoreV2 for encrypted storage. This type is kept for migration compatibility. */
+export interface LegacyKeyStore {
   [name: string]: {
     privateKey: string;
     address: string;
     publicKey: string;
   };
+}
+
+/** Alias for backward compatibility */
+export type KeyStore = LegacyKeyStore;
+
+// Encrypted keystore types
+
+export interface ScryptParams {
+  n: number;
+  r: number;
+  p: number;
+  dklen: number;
+}
+
+export interface EncryptedKey {
+  version: 1;
+  name: string;
+  address: string;
+  publicKey: string;
+  crypto: {
+    cipher: 'aes-256-gcm';
+    ciphertext: string;
+    cipherparams: {
+      iv: string;
+      tag: string;
+    };
+    kdf: 'scrypt';
+    kdfparams: ScryptParams & {
+      salt: string;
+    };
+  };
+}
+
+export interface KeyStoreV2 {
+  version: 2;
+  keys: Record<string, EncryptedKey>;
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration tests - run against live Republic testnet.
+ *
+ * Skipped by default. Set REPUBLIC_INTEGRATION=1 to enable.
+ * Requires REPUBLIC_TEST_KEY (hex private key) and REPUBLIC_TEST_ADDRESS env vars.
+ *
+ * Usage:
+ *   REPUBLIC_INTEGRATION=1 REPUBLIC_TEST_KEY=<hex> REPUBLIC_TEST_ADDRESS=<rai1...> npm run test:integration
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RepublicKey } from '../src/key.js';
+import { RepublicClient } from '../src/client.js';
+import { signTx, msgSend } from '../src/transaction.js';
+import { REPUBLIC_TESTNET } from '../src/constants.js';
+
+const SKIP = !process.env.REPUBLIC_INTEGRATION;
+const describeIntegration = SKIP ? describe.skip : describe;
+
+const TEST_KEY = process.env.REPUBLIC_TEST_KEY ?? '';
+const TEST_ADDRESS = process.env.REPUBLIC_TEST_ADDRESS ?? '';
+
+describeIntegration('Integration Tests (live chain)', () => {
+  const client = new RepublicClient(undefined, {
+    retryOptions: { maxRetries: 3, baseDelayMs: 2000 },
+  });
+
+  it('should connect to node and get status', async () => {
+    const status = await client.getStatus();
+    expect(status.nodeInfo.network).toBeTruthy();
+    expect(Number(status.syncInfo.latestBlockHeight)).toBeGreaterThan(0);
+  }, { timeout: 30000 });
+
+  it('should query balance for test address', async () => {
+    const balances = await client.getBalances(TEST_ADDRESS);
+    expect(Array.isArray(balances)).toBe(true);
+    // Test account should have some balance
+    expect(balances.length).toBeGreaterThan(0);
+  }, { timeout: 30000 });
+
+  it('should query account info', async () => {
+    const accountInfo = await client.getAccountInfo(TEST_ADDRESS);
+    expect(accountInfo.address).toBeTruthy();
+    expect(accountInfo.accountNumber).toBeDefined();
+    expect(accountInfo.sequence).toBeDefined();
+  }, { timeout: 30000 });
+
+  it('should list validators', async () => {
+    const validators = await client.getValidators();
+    expect(validators.length).toBeGreaterThan(0);
+    expect(validators[0].operatorAddress).toBeTruthy();
+    expect(validators[0].moniker).toBeTruthy();
+  }, { timeout: 30000 });
+
+  it('should get specific validator', async () => {
+    const validators = await client.getValidators();
+    const first = validators[0];
+    const validator = await client.getValidator(first.operatorAddress);
+    expect(validator.operatorAddress).toBe(first.operatorAddress);
+  }, { timeout: 30000 });
+
+  it('should query delegations', async () => {
+    const delegations = await client.getDelegations(TEST_ADDRESS);
+    expect(Array.isArray(delegations)).toBe(true);
+  }, { timeout: 30000 });
+
+  it('should query rewards', async () => {
+    const rewards = await client.getRewards(TEST_ADDRESS);
+    expect(Array.isArray(rewards)).toBe(true);
+  }, { timeout: 30000 });
+
+  // TX tests - sequential, self-transfer
+  describe('Transaction broadcast', () => {
+    let txHash: string;
+
+    it('should broadcast a self-transfer', async () => {
+      const key = RepublicKey.fromPrivateKey(TEST_KEY);
+      const address = key.getAddress();
+      expect(address).toBe(TEST_ADDRESS);
+
+      const accountInfo = await client.getAccountInfoSafe(address);
+
+      const msg = msgSend(address, address, [
+        { denom: REPUBLIC_TESTNET.denom, amount: '1' }, // 1 arai (minimal)
+      ]);
+
+      const txBytes = signTx(key, [msg], {
+        accountNumber: accountInfo.accountNumber,
+        sequence: accountInfo.sequence,
+      });
+
+      const result = await client.broadcastTx(txBytes);
+      expect(result.hash).toBeTruthy();
+      expect(result.hash).toHaveLength(64);
+      txHash = result.hash;
+    }, { timeout: 60000 });
+
+    it('should wait for TX inclusion', async () => {
+      expect(txHash).toBeTruthy();
+      const txResponse = await client.waitForTx(txHash, 30000);
+      expect(txResponse.hash).toBe(txHash);
+      expect(txResponse.height).toBeTruthy();
+    }, { timeout: 60000 });
+
+    it('should query broadcasted TX', async () => {
+      expect(txHash).toBeTruthy();
+      const txResponse = await client.getTx(txHash);
+      expect(txResponse.hash).toBe(txHash);
+      expect(Number(txResponse.height)).toBeGreaterThan(0);
+    }, { timeout: 30000 });
+  });
+});

--- a/tests/keystore.test.ts
+++ b/tests/keystore.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, existsSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import {
+  deriveKey,
+  encrypt,
+  decrypt,
+  encryptPrivateKey,
+  decryptPrivateKey,
+  isLegacyKeyStore,
+  migrateLegacyStore,
+  loadKeyStore,
+  saveKeyStore,
+} from '../src/keystore.js';
+import { KeystoreError } from '../src/errors.js';
+import type { LegacyKeyStore, KeyStoreV2 } from '../src/types.js';
+
+describe('Keystore', () => {
+  // ─── deriveKey ────────────────────────────────────────────────────────────
+
+  describe('deriveKey', () => {
+    it('should produce same key for same password and salt', () => {
+      const salt = Buffer.from('a'.repeat(64), 'hex');
+      const key1 = deriveKey('testpass', salt);
+      const key2 = deriveKey('testpass', salt);
+      expect(key1.toString('hex')).toBe(key2.toString('hex'));
+    });
+
+    it('should produce different keys for different passwords', () => {
+      const salt = Buffer.from('b'.repeat(64), 'hex');
+      const key1 = deriveKey('password1', salt);
+      const key2 = deriveKey('password2', salt);
+      expect(key1.toString('hex')).not.toBe(key2.toString('hex'));
+    });
+
+    it('should produce different keys for different salts', () => {
+      const salt1 = Buffer.from('a'.repeat(64), 'hex');
+      const salt2 = Buffer.from('b'.repeat(64), 'hex');
+      const key1 = deriveKey('samepass', salt1);
+      const key2 = deriveKey('samepass', salt2);
+      expect(key1.toString('hex')).not.toBe(key2.toString('hex'));
+    });
+
+    it('should produce 32-byte key by default', () => {
+      const salt = randomBytes(32);
+      const key = deriveKey('test', salt);
+      expect(key.length).toBe(32);
+    });
+
+    it('should respect custom params', () => {
+      const salt = randomBytes(32);
+      const key = deriveKey('test', salt, { n: 1024, r: 8, p: 1, dklen: 16 });
+      expect(key.length).toBe(16);
+    });
+  });
+
+  // ─── encrypt / decrypt ────────────────────────────────────────────────────
+
+  describe('encrypt/decrypt', () => {
+    it('should roundtrip correctly', () => {
+      const key = randomBytes(32);
+      const plaintext = Buffer.from('hello world');
+      const { ciphertext, iv, tag } = encrypt(plaintext, key);
+      const decrypted = decrypt(ciphertext, key, iv, tag);
+      expect(decrypted.toString()).toBe('hello world');
+    });
+
+    it('should fail with wrong key', () => {
+      const key1 = randomBytes(32);
+      const key2 = randomBytes(32);
+      const plaintext = Buffer.from('secret data');
+      const { ciphertext, iv, tag } = encrypt(plaintext, key1);
+      expect(() => decrypt(ciphertext, key2, iv, tag)).toThrow(KeystoreError);
+    });
+
+    it('should fail with tampered ciphertext', () => {
+      const key = randomBytes(32);
+      const plaintext = Buffer.from('important');
+      const { ciphertext, iv, tag } = encrypt(plaintext, key);
+      // Tamper with ciphertext
+      ciphertext[0] ^= 0xff;
+      expect(() => decrypt(ciphertext, key, iv, tag)).toThrow(KeystoreError);
+    });
+
+    it('should fail with tampered tag', () => {
+      const key = randomBytes(32);
+      const plaintext = Buffer.from('data');
+      const { ciphertext, iv, tag } = encrypt(plaintext, key);
+      tag[0] ^= 0xff;
+      expect(() => decrypt(ciphertext, key, iv, tag)).toThrow(KeystoreError);
+    });
+
+    it('should produce different ciphertexts for same plaintext (random IV)', () => {
+      const key = randomBytes(32);
+      const plaintext = Buffer.from('same data');
+      const result1 = encrypt(plaintext, key);
+      const result2 = encrypt(plaintext, key);
+      expect(result1.ciphertext.toString('hex')).not.toBe(result2.ciphertext.toString('hex'));
+    });
+  });
+
+  // ─── encryptPrivateKey / decryptPrivateKey ────────────────────────────────
+
+  describe('encryptPrivateKey/decryptPrivateKey', () => {
+    const testPrivateKey = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
+    it('should roundtrip correctly', () => {
+      const crypto = encryptPrivateKey(testPrivateKey, 'mypassword');
+      const decrypted = decryptPrivateKey(crypto, 'mypassword');
+      expect(decrypted).toBe(testPrivateKey);
+    });
+
+    it('should fail with wrong password', () => {
+      const crypto = encryptPrivateKey(testPrivateKey, 'correct');
+      expect(() => decryptPrivateKey(crypto, 'wrong')).toThrow(KeystoreError);
+    });
+
+    it('should throw on empty password for encrypt', () => {
+      expect(() => encryptPrivateKey(testPrivateKey, '')).toThrow(KeystoreError);
+    });
+
+    it('should throw on empty password for decrypt', () => {
+      const crypto = encryptPrivateKey(testPrivateKey, 'pass');
+      expect(() => decryptPrivateKey(crypto, '')).toThrow(KeystoreError);
+    });
+
+    it('should work with unicode password', () => {
+      const crypto = encryptPrivateKey(testPrivateKey, '密码测试🔑');
+      const decrypted = decryptPrivateKey(crypto, '密码测试🔑');
+      expect(decrypted).toBe(testPrivateKey);
+    });
+
+    it('should work with long password', () => {
+      const longPassword = 'a'.repeat(1000);
+      const crypto = encryptPrivateKey(testPrivateKey, longPassword);
+      const decrypted = decryptPrivateKey(crypto, longPassword);
+      expect(decrypted).toBe(testPrivateKey);
+    });
+
+    it('should set correct crypto fields', () => {
+      const crypto = encryptPrivateKey(testPrivateKey, 'pass');
+      expect(crypto.cipher).toBe('aes-256-gcm');
+      expect(crypto.kdf).toBe('scrypt');
+      expect(crypto.kdfparams.n).toBe(16384);
+      expect(crypto.kdfparams.r).toBe(8);
+      expect(crypto.kdfparams.p).toBe(1);
+      expect(crypto.kdfparams.dklen).toBe(32);
+      expect(crypto.kdfparams.salt).toHaveLength(64); // 32 bytes hex
+      expect(crypto.cipherparams.iv).toHaveLength(24); // 12 bytes hex
+      expect(crypto.cipherparams.tag).toHaveLength(32); // 16 bytes hex
+    });
+  });
+
+  // ─── isLegacyKeyStore ─────────────────────────────────────────────────────
+
+  describe('isLegacyKeyStore', () => {
+    it('should detect legacy format (no version field)', () => {
+      const legacy = {
+        mykey: { privateKey: 'abc', address: 'rai1...', publicKey: '02...' },
+      };
+      expect(isLegacyKeyStore(legacy)).toBe(true);
+    });
+
+    it('should reject v2 format', () => {
+      const v2: KeyStoreV2 = {
+        version: 2,
+        keys: {},
+      };
+      expect(isLegacyKeyStore(v2)).toBe(false);
+    });
+
+    it('should reject null', () => {
+      expect(isLegacyKeyStore(null)).toBe(false);
+    });
+
+    it('should reject non-objects', () => {
+      expect(isLegacyKeyStore('string')).toBe(false);
+      expect(isLegacyKeyStore(42)).toBe(false);
+    });
+
+    it('should detect empty legacy store', () => {
+      expect(isLegacyKeyStore({})).toBe(true);
+    });
+  });
+
+  // ─── migrateLegacyStore ───────────────────────────────────────────────────
+
+  describe('migrateLegacyStore', () => {
+    it('should migrate all keys correctly', () => {
+      const legacy: LegacyKeyStore = {
+        key1: { privateKey: 'aa'.repeat(32), address: 'rai1addr1', publicKey: '02pub1' },
+        key2: { privateKey: 'bb'.repeat(32), address: 'rai1addr2', publicKey: '02pub2' },
+      };
+
+      const migrated = migrateLegacyStore(legacy, 'password');
+
+      expect(migrated.version).toBe(2);
+      expect(Object.keys(migrated.keys)).toHaveLength(2);
+
+      // Check key1
+      expect(migrated.keys.key1.name).toBe('key1');
+      expect(migrated.keys.key1.address).toBe('rai1addr1');
+      expect(migrated.keys.key1.publicKey).toBe('02pub1');
+      expect(migrated.keys.key1.version).toBe(1);
+
+      // Verify decryption works
+      const decrypted1 = decryptPrivateKey(migrated.keys.key1.crypto, 'password');
+      expect(decrypted1).toBe('aa'.repeat(32));
+
+      const decrypted2 = decryptPrivateKey(migrated.keys.key2.crypto, 'password');
+      expect(decrypted2).toBe('bb'.repeat(32));
+    });
+
+    it('should handle empty legacy store', () => {
+      const migrated = migrateLegacyStore({}, 'password');
+      expect(migrated.version).toBe(2);
+      expect(Object.keys(migrated.keys)).toHaveLength(0);
+    });
+  });
+
+  // ─── loadKeyStore / saveKeyStore ──────────────────────────────────────────
+
+  describe('loadKeyStore/saveKeyStore', () => {
+    const testDir = join(tmpdir(), `republic-test-${Date.now()}`);
+    const testFile = join(testDir, 'keys.json');
+
+    beforeEach(() => {
+      if (!existsSync(testDir)) {
+        mkdirSync(testDir, { recursive: true });
+      }
+    });
+
+    afterEach(() => {
+      if (existsSync(testDir)) {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return null for non-existent file', () => {
+      const result = loadKeyStore(join(testDir, 'nonexistent.json'));
+      expect(result).toBeNull();
+    });
+
+    it('should save and load v2 store', () => {
+      const store: KeyStoreV2 = {
+        version: 2,
+        keys: {
+          test: {
+            version: 1,
+            name: 'test',
+            address: 'rai1test',
+            publicKey: '02test',
+            crypto: encryptPrivateKey('cc'.repeat(32), 'pass'),
+          },
+        },
+      };
+
+      saveKeyStore(testFile, store);
+      const loaded = loadKeyStore(testFile);
+
+      expect(loaded).not.toBeNull();
+      expect(isLegacyKeyStore(loaded)).toBe(false);
+      const loadedV2 = loaded as KeyStoreV2;
+      expect(loadedV2.version).toBe(2);
+      expect(loadedV2.keys.test.address).toBe('rai1test');
+    });
+
+    it('should load legacy format', () => {
+      const legacy = {
+        mykey: { privateKey: 'dd'.repeat(32), address: 'rai1old', publicKey: '02old' },
+      };
+      writeFileSync(testFile, JSON.stringify(legacy), 'utf-8');
+
+      const loaded = loadKeyStore(testFile);
+      expect(loaded).not.toBeNull();
+      expect(isLegacyKeyStore(loaded)).toBe(true);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    exclude: ['tests/integration.test.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary

- **Encrypted Keystore**: AES-256-GCM + scrypt KDF for private keys at rest (zero new dependencies)
- **Integration Tests**: 10 live chain test scenarios (queries + TX broadcast), weekly CI schedule
- **npm Publish Workflow**: GitHub Release → npm with provenance, dry-run before publish
- **v0.2.1**: Branch protection tightened (1 review required, CODEOWNERS enforced)

## Changes

### New Files
- `src/keystore.ts` - encrypt/decrypt/migrate keystore operations
- `tests/keystore.test.ts` - 27 keystore tests
- `tests/integration.test.ts` - 10 live chain integration tests
- `.github/workflows/integration.yml` - weekly integration CI
- `.github/workflows/publish.yml` - npm publish on release

### Modified Files
- `src/types.ts` - EncryptedKey, KeyStoreV2, ScryptParams types
- `src/errors.ts` - KeystoreError class
- `src/index.ts` - new exports
- `bin/cli.ts` - password prompts, --no-password flag, keys migrate command
- `package.json` - v0.3.0, homepage/bugs, test:integration script
- `vitest.config.ts` - exclude integration tests from default run
- `CHANGELOG.md` - v0.2.1 + v0.3.0 sections
- `README.md` - npm install, npm badge, encrypted keystore feature

## Test Results
- **132 unit tests passing** (105 existing + 27 new keystore tests)
- Lint clean
- Build: ESM + CJS + DTS

## Test Plan
- [x] All 132 unit tests pass
- [x] Lint passes
- [x] Build produces ESM, CJS, DTS outputs
- [ ] NPM_TOKEN secret needs to be added manually for publish workflow
- [ ] REPUBLIC_TEST_KEY + REPUBLIC_TEST_ADDRESS secrets for integration tests