### PR TITLE
chore: add workflow_dispatch to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to publish workflow
- Allows manual npm publish for first-time setup and re-publish

## Test Plan
- [x] Workflow syntax valid