### PR TITLE
fix: prevent legacy keystore data loss on encrypted key operations

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,6 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +20,8 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npm run test:integration
+      - name: Run integration tests
+        run: npm run test:integration
         env:
           REPUBLIC_INTEGRATION: '1'
           REPUBLIC_TEST_KEY: ${{ secrets.REPUBLIC_TEST_KEY }}

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -52,9 +52,9 @@ function loadKeysV2(): KeyStoreV2 {
   }
 
   if (isLegacyKeyStore(data)) {
-    // Return as-is but wrapped - migration needs password so can't do it here
-    // Callers should check and migrate when needed
-    return { version: 2, keys: {} };
+    console.error('Legacy plaintext keystore detected.');
+    console.error('Run "republic-sdk keys migrate" to encrypt your keys before creating new encrypted keys.');
+    process.exit(1);
   }
 
   return data;
@@ -163,14 +163,19 @@ keys
           publicKey: key.publicKey,
         };
         ensureConfigDir();
-        const { writeFileSync, chmodSync } = await import('fs');
-        writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
-        try { chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
+        const fs = await import('fs');
+        fs.writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
+        try { fs.chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
         console.log(`Key created: ${name}`);
         console.log(`Address:     ${key.getAddress()}`);
         console.log(`Public Key:  ${key.publicKey}`);
         return;
       }
+
+      // Legacy store exists but user wants encrypted — force migration first
+      console.error('Legacy plaintext keystore detected.');
+      console.error('Run "republic-sdk keys migrate" first, then create new keys.');
+      process.exit(1);
     }
 
     const store = loadKeysV2();
@@ -183,17 +188,17 @@ keys
     const address = key.getAddress();
 
     if (opts.noPassword) {
-      // Store in legacy format for no-password mode
-      const legacy = loadLegacyKeys();
+      // No-password mode with no existing legacy store: create new legacy file
+      const legacy: LegacyKeyStore = {};
       legacy[name] = {
         privateKey: key.privateKey,
         address,
         publicKey: key.publicKey,
       };
       ensureConfigDir();
-      const { writeFileSync, chmodSync } = await import('fs');
-      writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
-      try { chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
+      const fs = await import('fs');
+      fs.writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
+      try { fs.chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
     } else {
       const password = await getPassword('Create password for key: ');
       const confirmPassword = await getPassword('Confirm password: ');
@@ -315,10 +320,17 @@ keys
           publicKey: key.publicKey,
         };
         ensureConfigDir();
-        const { writeFileSync, chmodSync } = await import('fs');
-        writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
-        try { chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
+        const fs = await import('fs');
+        fs.writeFileSync(KEYS_FILE, JSON.stringify(legacy, null, 2), 'utf-8');
+        try { fs.chmodSync(KEYS_FILE, 0o600); } catch { /* Windows */ }
       } else {
+        // Block if legacy store exists — force migration first
+        if (hasLegacyKeys()) {
+          console.error('Legacy plaintext keystore detected.');
+          console.error('Run "republic-sdk keys migrate" first, then import keys.');
+          process.exit(1);
+        }
+
         const store = loadKeysV2();
         if (store.keys[name]) {
           console.error(`Key "${name}" already exists.`);


### PR DESCRIPTION
## Summary
Fixes a **critical data loss bug** where creating or importing encrypted keys with a legacy plaintext keystore would silently overwrite all existing plaintext keys.

## Root Cause
`loadKeysV2()` returned an empty `{ version: 2, keys: {} }` when a legacy store was detected. Subsequent `saveKeyStore()` calls would overwrite the file, destroying all plaintext keys.

## Fix
- `loadKeysV2()` now **exits with a migration prompt** instead of returning empty store
- `keys create` (encrypted mode): blocks when legacy store exists, requires `keys migrate` first
- `keys import` (encrypted mode): same guard added
- `--no-password` mode: unaffected (correctly operates on legacy format)

## Also Fixed
- Integration workflow: removed `continue-on-error: true` so failures are visible in CI status

## Affected Code Paths
- `bin/cli.ts:48` (loadKeysV2)
- `bin/cli.ts:176` (keys create → encrypted mode)
- `bin/cli.ts:322` (keys import → encrypted mode)

## Test Plan
- [x] 132 tests pass
- [x] Lint clean