### PR TITLE
fix: stabilize release-please and sync package-lock.json

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          release-type: node
-          package-name: republic-sdk
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "republic-sdk",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "republic-sdk",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",
@@ -16,7 +16,7 @@
         "commander": "^12.0.0"
       },
       "bin": {
-        "republic-sdk": "dist/cli.js"
+        "republic-sdk": "dist/cli.cjs"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",


### PR DESCRIPTION
## Summary
Fixes release-please automation failure and lockfile drift.

## Fixes
- Workflow: switch to manifest mode (config-file + manifest-file)
- Lockfile: synced to 0.3.0
- Repo settings: enabled Actions PR creation + conversation resolution

## Test Plan
- [x] 132 tests pass, lint clean