### PR TITLE
feat(panoptes): PanoptesClient integration

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,8 @@ import axios, { AxiosInstance } from 'axios';
 import { REPUBLIC_TESTNET } from './constants.js';
 import { sleep, retry } from './utils.js';
 import type { RetryOptions } from './utils.js';
-import { RpcError, BroadcastError, TimeoutError, AccountNotFoundError } from './errors.js';
+import { RpcError, BroadcastError, TimeoutError, AccountNotFoundError, ValidationError } from './errors.js';
+import { PanoptesClient } from './panoptes.js';
 import type {
   AccountInfo,
   BroadcastResult,
@@ -10,6 +11,7 @@ import type {
   Coin,
   Delegation,
   NodeStatus,
+  PreflightResult,
   Proposal,
   Reward,
   TxResponse,
@@ -18,6 +20,9 @@ import type {
 
 export interface ClientOptions {
   retryOptions?: Partial<RetryOptions>;
+  endpointStrategy?: 'static' | 'panoptes';
+  panoptesUrl?: string;
+  panoptesApiKey?: string;
 }
 
 export class RepublicClient {
@@ -25,6 +30,7 @@ export class RepublicClient {
   private rest: AxiosInstance;
   readonly config: ChainConfig;
   private retryOpts: Partial<RetryOptions>;
+  private panoptesClient: PanoptesClient | null = null;
 
   constructor(config?: Partial<ChainConfig>, options?: ClientOptions) {
     this.config = { ...REPUBLIC_TESTNET, ...config };
@@ -40,6 +46,13 @@ export class RepublicClient {
       baseURL: this.config.rest,
       timeout: 15000,
     });
+
+    if (options?.endpointStrategy === 'panoptes' || options?.panoptesUrl || options?.panoptesApiKey) {
+      this.panoptesClient = new PanoptesClient({
+        baseUrl: options.panoptesUrl,
+        apiKey: options.panoptesApiKey,
+      });
+    }
   }
 
   /** Tendermint JSON-RPC call with retry */
@@ -451,5 +464,38 @@ export class RepublicClient {
       status: p.status,
       votingEndTime: p.voting_end_time || '',
     };
+  }
+
+  // ─── Panoptes Integration ───────────────────────────────────────────────────
+
+  /** Broadcast with optional Panoptes preflight check */
+  async broadcastTxSafe(
+    txBytes: string,
+    preflightParams?: {
+      fromAddress: string;
+      toAddress?: string;
+      amount?: string;
+      denom?: string;
+    },
+    mode: 'sync' | 'async' | 'commit' = 'sync',
+  ): Promise<BroadcastResult & { preflight?: PreflightResult }> {
+    let preflightResult: PreflightResult | undefined;
+
+    if (preflightParams && this.panoptesClient) {
+      try {
+        preflightResult = await this.panoptesClient.preflight(preflightParams);
+        if (!preflightResult.safe) {
+          throw new ValidationError(
+            `Preflight check failed: ${preflightResult.recommendation}`,
+          );
+        }
+      } catch (err) {
+        if (err instanceof ValidationError) throw err;
+        // Panoptes unavailable — proceed without preflight
+      }
+    }
+
+    const result = await this.broadcastTx(txBytes, mode);
+    return { ...result, preflight: preflightResult };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 export { RepublicKey, hexToBytes, bytesToHex, addressToBytes, bytesToAddress } from './key.js';
 export { RepublicClient } from './client.js';
 export type { ClientOptions } from './client.js';
+export { PanoptesClient } from './panoptes.js';
 export { JobManager } from './job.js';
 
 // Errors
@@ -88,4 +89,9 @@ export type {
   EncryptedKey,
   KeyStoreV2,
   ScryptParams,
+  PanoptesClientOptions,
+  PanoptesEndpoint,
+  PanoptesNetworkStats,
+  PanoptesValidatorScore,
+  PreflightResult,
 } from './types.js';

--- a/src/panoptes.ts
+++ b/src/panoptes.ts
@@ -15,7 +15,11 @@ export class PanoptesClient {
   private apiKey: string | null;
 
   constructor(options?: PanoptesClientOptions) {
-    const baseURL = options?.baseUrl ?? DEFAULT_BASE_URL;
+    const url = options?.baseUrl ?? DEFAULT_BASE_URL;
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      throw new Error('baseUrl must start with http:// or https://');
+    }
+    const baseURL = url.replace(/\/+$/, '');
     const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
     this.apiKey = options?.apiKey ?? null;
 
@@ -27,7 +31,7 @@ export class PanoptesClient {
 
   /** Get the best endpoint for a given type */
   async getBestEndpoint(type: 'rpc' | 'rest' | 'evm-rpc'): Promise<PanoptesEndpoint> {
-    const { data } = await this.http.get(`/api/endpoints/best?type=${type}`);
+    const { data } = await this.http.get(`/api/endpoints/best?type=${encodeURIComponent(type)}`);
     return data as PanoptesEndpoint;
   }
 
@@ -55,7 +59,7 @@ export class PanoptesClient {
 
   /** Get validator score */
   async getValidatorScore(validatorId: string): Promise<PanoptesValidatorScore> {
-    const { data } = await this.http.get(`/api/validators/${validatorId}`);
+    const { data } = await this.http.get(`/api/validators/${encodeURIComponent(validatorId)}`);
     return {
       validatorId,
       score: data.validator?.score ?? 0,

--- a/src/panoptes.ts
+++ b/src/panoptes.ts
@@ -1,0 +1,76 @@
+import axios, { AxiosInstance } from 'axios';
+import type {
+  PanoptesClientOptions,
+  PanoptesEndpoint,
+  PanoptesNetworkStats,
+  PanoptesValidatorScore,
+  PreflightResult,
+} from './types.js';
+
+const DEFAULT_BASE_URL = 'https://panoptes.republicai.io';
+const DEFAULT_TIMEOUT = 10000;
+
+export class PanoptesClient {
+  private http: AxiosInstance;
+  private apiKey: string | null;
+
+  constructor(options?: PanoptesClientOptions) {
+    const baseURL = options?.baseUrl ?? DEFAULT_BASE_URL;
+    const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
+    this.apiKey = options?.apiKey ?? null;
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) headers['x-api-key'] = this.apiKey;
+
+    this.http = axios.create({ baseURL, timeout, headers });
+  }
+
+  /** Get the best endpoint for a given type */
+  async getBestEndpoint(type: 'rpc' | 'rest' | 'evm-rpc'): Promise<PanoptesEndpoint> {
+    const { data } = await this.http.get(`/api/endpoints/best?type=${type}`);
+    return data as PanoptesEndpoint;
+  }
+
+  /** Run preflight checks before broadcasting */
+  async preflight(params: {
+    fromAddress: string;
+    toAddress?: string;
+    amount?: string;
+    denom?: string;
+  }): Promise<PreflightResult> {
+    const { data } = await this.http.post('/api/preflight', params);
+    return data as PreflightResult;
+  }
+
+  /** Get network stats */
+  async getNetworkStats(): Promise<PanoptesNetworkStats> {
+    const { data } = await this.http.get('/api/stats');
+    return {
+      totalValidators: data.latest?.totalValidators ?? 0,
+      activeValidators: data.latest?.activeValidators ?? 0,
+      totalStaked: data.latest?.totalStaked ?? '0',
+      blockHeight: String(data.latest?.blockHeight ?? '0'),
+    } as PanoptesNetworkStats;
+  }
+
+  /** Get validator score */
+  async getValidatorScore(validatorId: string): Promise<PanoptesValidatorScore> {
+    const { data } = await this.http.get(`/api/validators/${validatorId}`);
+    return {
+      validatorId,
+      score: data.validator?.score ?? 0,
+      missedBlockRate: data.validator?.missedBlocks ?? 0,
+      governanceScore: 0,
+    } as PanoptesValidatorScore;
+  }
+
+  /** Check if Panoptes API is healthy */
+  async isHealthy(): Promise<boolean> {
+    try {
+      const { data } = await this.http.get('/api/health');
+      return data.status === 'healthy';
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,3 +228,41 @@ export interface KeyStoreV2 {
   version: 2;
   keys: Record<string, EncryptedKey>;
 }
+
+// Panoptes integration types
+
+export interface PanoptesClientOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  timeout?: number;
+}
+
+export interface PanoptesEndpoint {
+  url: string;
+  score: number;
+  type: string;
+}
+
+export interface PanoptesNetworkStats {
+  totalValidators: number;
+  activeValidators: number;
+  totalStaked: string;
+  blockHeight: string;
+}
+
+export interface PanoptesValidatorScore {
+  validatorId: string;
+  score: number;
+  missedBlockRate: number;
+  governanceScore: number;
+}
+
+export interface PreflightResult {
+  safe: boolean;
+  checks: {
+    name: string;
+    passed: boolean;
+    message: string;
+  }[];
+  recommendation: string;
+}

--- a/tests/client-panoptes.test.ts
+++ b/tests/client-panoptes.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RepublicClient } from '../src/client';
+import { ValidationError } from '../src/errors';
+import { REPUBLIC_TESTNET } from '../src/constants';
+
+// Mock axios
+vi.mock('axios', () => {
+  const mockRpcPost = vi.fn();
+  const mockRestGet = vi.fn();
+  const mockRestPost = vi.fn();
+  const mockPanoptesGet = vi.fn();
+  const mockPanoptesPost = vi.fn();
+
+  return {
+    default: {
+      create: vi.fn((config: { baseURL: string }) => {
+        if (config.baseURL === REPUBLIC_TESTNET.rpc) {
+          return { post: mockRpcPost };
+        }
+        if (config.baseURL === REPUBLIC_TESTNET.rest) {
+          return { get: mockRestGet, post: mockRestPost };
+        }
+        // Panoptes client
+        return { get: mockPanoptesGet, post: mockPanoptesPost };
+      }),
+      isAxiosError: (err: unknown) =>
+        err && typeof err === 'object' && 'response' in (err as Record<string, unknown>),
+    },
+    __mockRpcPost: mockRpcPost,
+    __mockPanoptesPost: mockPanoptesPost,
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockRpcPost: ReturnType<typeof vi.fn>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockPanoptesPost: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  const axiosMock = await import('axios');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockRpcPost = (axiosMock as any).__mockRpcPost;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockPanoptesPost = (axiosMock as any).__mockPanoptesPost;
+  vi.clearAllMocks();
+});
+
+describe('RepublicClient - broadcastTxSafe', () => {
+  it('should broadcast without preflight when panoptes is not configured', async () => {
+    mockRpcPost.mockResolvedValueOnce({
+      data: {
+        jsonrpc: '2.0', id: 1,
+        result: { hash: 'ABC123', code: 0, log: '' },
+      },
+    });
+
+    const client = new RepublicClient();
+    const result = await client.broadcastTxSafe('dHhieXRlcw==', {
+      fromAddress: 'rai1test',
+    });
+
+    expect(result.hash).toBe('ABC123');
+    expect(result.preflight).toBeUndefined();
+  });
+
+  it('should run preflight and broadcast when panoptes is configured and safe', async () => {
+    mockPanoptesPost.mockResolvedValueOnce({
+      data: {
+        safe: true,
+        checks: [{ name: 'balance', passed: true, message: 'OK' }],
+        recommendation: 'Safe to proceed',
+      },
+    });
+    mockRpcPost.mockResolvedValueOnce({
+      data: {
+        jsonrpc: '2.0', id: 1,
+        result: { hash: 'DEF456', code: 0, log: '' },
+      },
+    });
+
+    const client = new RepublicClient(undefined, {
+      panoptesUrl: 'https://panoptes.republicai.io',
+    });
+    const result = await client.broadcastTxSafe('dHhieXRlcw==', {
+      fromAddress: 'rai1test',
+      toAddress: 'rai1dest',
+      amount: '1000000',
+    });
+
+    expect(result.hash).toBe('DEF456');
+    expect(result.preflight?.safe).toBe(true);
+  });
+
+  it('should throw ValidationError when preflight is not safe', async () => {
+    mockPanoptesPost.mockResolvedValueOnce({
+      data: {
+        safe: false,
+        checks: [{ name: 'balance', passed: false, message: 'Insufficient balance' }],
+        recommendation: 'Top up your account before proceeding',
+      },
+    });
+
+    const client = new RepublicClient(undefined, {
+      panoptesUrl: 'https://panoptes.republicai.io',
+    });
+
+    await expect(
+      client.broadcastTxSafe('dHhieXRlcw==', { fromAddress: 'rai1test' }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('should proceed without preflight when panoptes is unavailable', async () => {
+    mockPanoptesPost.mockRejectedValueOnce(new Error('Connection refused'));
+    mockRpcPost.mockResolvedValueOnce({
+      data: {
+        jsonrpc: '2.0', id: 1,
+        result: { hash: 'GHI789', code: 0, log: '' },
+      },
+    });
+
+    const client = new RepublicClient(undefined, {
+      panoptesUrl: 'https://panoptes.republicai.io',
+    });
+    const result = await client.broadcastTxSafe('dHhieXRlcw==', {
+      fromAddress: 'rai1test',
+    });
+
+    expect(result.hash).toBe('GHI789');
+    expect(result.preflight).toBeUndefined();
+  });
+
+  it('should broadcast without preflight when no preflightParams provided', async () => {
+    mockRpcPost.mockResolvedValueOnce({
+      data: {
+        jsonrpc: '2.0', id: 1,
+        result: { hash: 'JKL012', code: 0, log: '' },
+      },
+    });
+
+    const client = new RepublicClient(undefined, {
+      panoptesUrl: 'https://panoptes.republicai.io',
+    });
+    const result = await client.broadcastTxSafe('dHhieXRlcw==');
+
+    expect(result.hash).toBe('JKL012');
+    expect(result.preflight).toBeUndefined();
+  });
+});

--- a/tests/panoptes.test.ts
+++ b/tests/panoptes.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { PanoptesClient } from '../src/panoptes';
+
+vi.mock('axios');
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+vi.mocked(axios.create).mockReturnValue({ get: mockGet, post: mockPost } as any);
+
+describe('PanoptesClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(axios.create).mockReturnValue({ get: mockGet, post: mockPost } as any);
+  });
+
+  describe('constructor', () => {
+    it('should use default baseUrl and timeout', () => {
+      new PanoptesClient();
+      expect(axios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://panoptes.republicai.io',
+          timeout: 10000,
+        }),
+      );
+    });
+
+    it('should use custom options', () => {
+      new PanoptesClient({
+        baseUrl: 'http://localhost:3000',
+        apiKey: 'test-key',
+        timeout: 5000,
+      });
+      expect(axios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'http://localhost:3000',
+          timeout: 5000,
+          headers: expect.objectContaining({ 'x-api-key': 'test-key' }),
+        }),
+      );
+    });
+
+    it('should not include x-api-key header when no apiKey provided', () => {
+      new PanoptesClient();
+      expect(axios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.not.objectContaining({ 'x-api-key': expect.anything() }),
+        }),
+      );
+    });
+  });
+
+  describe('getBestEndpoint', () => {
+    it('should return best endpoint for type', async () => {
+      const endpoint = { url: 'https://rpc.republicai.io', score: 95, type: 'rpc' };
+      mockGet.mockResolvedValueOnce({ data: endpoint });
+
+      const client = new PanoptesClient();
+      const result = await client.getBestEndpoint('rpc');
+
+      expect(mockGet).toHaveBeenCalledWith('/api/endpoints/best?type=rpc');
+      expect(result).toEqual(endpoint);
+    });
+  });
+
+  describe('preflight', () => {
+    it('should return preflight result', async () => {
+      const preflightResult = {
+        safe: true,
+        checks: [{ name: 'balance', passed: true, message: 'OK' }],
+        recommendation: 'Safe to proceed',
+      };
+      mockPost.mockResolvedValueOnce({ data: preflightResult });
+
+      const client = new PanoptesClient();
+      const result = await client.preflight({
+        fromAddress: 'rai1test',
+        toAddress: 'rai1dest',
+        amount: '1000000',
+        denom: 'arai',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith('/api/preflight', {
+        fromAddress: 'rai1test',
+        toAddress: 'rai1dest',
+        amount: '1000000',
+        denom: 'arai',
+      });
+      expect(result.safe).toBe(true);
+    });
+  });
+
+  describe('getNetworkStats', () => {
+    it('should parse network stats', async () => {
+      mockGet.mockResolvedValueOnce({
+        data: {
+          latest: {
+            totalValidators: 50,
+            activeValidators: 40,
+            totalStaked: '1000000000000',
+            blockHeight: 123456,
+          },
+        },
+      });
+
+      const client = new PanoptesClient();
+      const stats = await client.getNetworkStats();
+
+      expect(stats.totalValidators).toBe(50);
+      expect(stats.activeValidators).toBe(40);
+      expect(stats.totalStaked).toBe('1000000000000');
+      expect(stats.blockHeight).toBe('123456');
+    });
+
+    it('should return defaults when latest is missing', async () => {
+      mockGet.mockResolvedValueOnce({ data: {} });
+
+      const client = new PanoptesClient();
+      const stats = await client.getNetworkStats();
+
+      expect(stats.totalValidators).toBe(0);
+      expect(stats.activeValidators).toBe(0);
+      expect(stats.totalStaked).toBe('0');
+      expect(stats.blockHeight).toBe('0');
+    });
+  });
+
+  describe('getValidatorScore', () => {
+    it('should parse validator score', async () => {
+      mockGet.mockResolvedValueOnce({
+        data: {
+          validator: { score: 92, missedBlocks: 5 },
+        },
+      });
+
+      const client = new PanoptesClient();
+      const score = await client.getValidatorScore('raivaloper1test');
+
+      expect(mockGet).toHaveBeenCalledWith('/api/validators/raivaloper1test');
+      expect(score.validatorId).toBe('raivaloper1test');
+      expect(score.score).toBe(92);
+      expect(score.missedBlockRate).toBe(5);
+      expect(score.governanceScore).toBe(0);
+    });
+
+    it('should return defaults when validator data is missing', async () => {
+      mockGet.mockResolvedValueOnce({ data: {} });
+
+      const client = new PanoptesClient();
+      const score = await client.getValidatorScore('raivaloper1unknown');
+
+      expect(score.score).toBe(0);
+      expect(score.missedBlockRate).toBe(0);
+    });
+  });
+
+  describe('isHealthy', () => {
+    it('should return true when API is healthy', async () => {
+      mockGet.mockResolvedValueOnce({ data: { status: 'healthy' } });
+
+      const client = new PanoptesClient();
+      const healthy = await client.isHealthy();
+
+      expect(healthy).toBe(true);
+    });
+
+    it('should return false when API returns non-healthy status', async () => {
+      mockGet.mockResolvedValueOnce({ data: { status: 'degraded' } });
+
+      const client = new PanoptesClient();
+      const healthy = await client.isHealthy();
+
+      expect(healthy).toBe(false);
+    });
+
+    it('should return false when API request fails', async () => {
+      mockGet.mockRejectedValueOnce(new Error('Connection refused'));
+
+      const client = new PanoptesClient();
+      const healthy = await client.isHealthy();
+
+      expect(healthy).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `PanoptesClient` class for direct Panoptes API integration (endpoint selection, preflight checks, network stats, validator scores, health monitoring)
- Add `broadcastTxSafe()` method to `RepublicClient` that runs optional Panoptes preflight checks before broadcasting transactions
- Add `endpointStrategy`, `panoptesUrl`, and `panoptesApiKey` options to `ClientOptions`
- Export all Panoptes types and client from package entry point

## Changes

### New files
- `src/panoptes.ts` - PanoptesClient class with 5 API methods
- `tests/panoptes.test.ts` - 12 unit tests for PanoptesClient
- `tests/client-panoptes.test.ts` - 5 unit tests for broadcastTxSafe

### Modified files
- `src/types.ts` - Added Panoptes integration types (PanoptesClientOptions, PanoptesEndpoint, PanoptesNetworkStats, PanoptesValidatorScore, PreflightResult)
- `src/client.ts` - Added panoptesClient field, broadcastTxSafe method, extended ClientOptions
- `src/index.ts` - Added PanoptesClient and type exports

## Test plan

- [x] TypeScript compilation: `npx tsc --noEmit` - 0 errors
- [x] Unit tests: `npx vitest run` - 149/149 passed (17 new tests)
- [ ] Verify PanoptesClient constructor defaults and custom options
- [ ] Verify broadcastTxSafe with/without preflight
- [ ] Verify graceful fallback when Panoptes is unavailable
- [ ] Verify ValidationError thrown when preflight fails