### PR TITLE
fix: wrap JSON.parse in job status with try-catch

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -72,9 +72,14 @@ export class JobManager {
       throw new ValidationError(`Job ${jobId} not found`);
     }
 
-    const decoded = JSON.parse(
-      Buffer.from(result.value, 'base64').toString(),
-    );
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(
+        Buffer.from(result.value, 'base64').toString(),
+      );
+    } catch {
+      throw new ValidationError(`Invalid job status response for job ${jobId}`);
+    }
 
     return decoded as JobStatus;
   }


### PR DESCRIPTION
## Summary
- `JobManager.getJobStatus()` now wraps `JSON.parse()` in try-catch, throwing `ValidationError` instead of crashing on malformed ABCI query responses.

## Changes
| File | Change |
|------|--------|
| `src/job.ts` | Wrap JSON.parse with try-catch + ValidationError |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 182/182 passed
- [x] `npm run build` — success (ESM + CJS + DTS)