### PR TITLE
fix: post-audit hardening (keystore, client, CLI)

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
-import { existsSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { RepublicKey } from '../src/key.js';
 import { RepublicClient } from '../src/client.js';
@@ -18,6 +19,9 @@ import {
   promptPassword,
 } from '../src/keystore.js';
 import type { KeyStoreV2, LegacyKeyStore, EncryptedKey } from '../src/types.js';
+
+const __cli_dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__cli_dirname, '..', 'package.json'), 'utf-8')) as { version: string };
 
 const CONFIG_DIR = join(homedir(), '.republic-sdk');
 const KEYS_FILE = join(CONFIG_DIR, 'keys.json');
@@ -132,7 +136,7 @@ const program = new Command();
 program
   .name('republic-sdk')
   .description('CLI for Republic AI blockchain')
-  .version('0.3.0');
+  .version(pkg.version);
 
 // ─── Keys ─────────────────────────────────────────────────────────────────────
 
@@ -188,6 +192,12 @@ keys
     const address = key.getAddress();
 
     if (opts.noPassword) {
+      // Guard: V2 encrypted store has keys — refuse no-password
+      if (Object.keys(store.keys).length > 0) {
+        console.error('Cannot use --no-password: encrypted keys exist.');
+        console.error('Export keys first or use password-based storage.');
+        process.exit(1);
+      }
       // No-password mode with no existing legacy store: create new legacy file
       const legacy: LegacyKeyStore = {};
       legacy[name] = {
@@ -309,6 +319,16 @@ keys
       const address = key.getAddress();
 
       if (opts.noPassword) {
+        // Guard: check if V2 store exists with keys
+        const rawData = loadKeyStore(KEYS_FILE);
+        if (rawData !== null && !isLegacyKeyStore(rawData)) {
+          const v2 = rawData as KeyStoreV2;
+          if (Object.keys(v2.keys).length > 0) {
+            console.error('Cannot use --no-password: encrypted keys exist.');
+            console.error('Export keys first or use password-based storage.');
+            process.exit(1);
+          }
+        }
         const legacy = loadLegacyKeys();
         if (legacy[name]) {
           console.error(`Key "${name}" already exists.`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -256,8 +256,11 @@ export class RepublicClient {
         gasUsed: result.tx_result.gas_used,
         events: result.tx_result.events,
       };
-    } catch {
-      return null;
+    } catch (err) {
+      // RPC "tx not found" → return null (normal polling)
+      if (err instanceof RpcError) return null;
+      // Infrastructure errors → rethrow (network down, timeout, etc.)
+      throw err;
     }
   }
 

--- a/src/keystore.ts
+++ b/src/keystore.ts
@@ -117,7 +117,12 @@ export function migrateLegacyStore(legacy: LegacyKeyStore, password: string): Ke
 export function loadKeyStore(filePath: string): KeyStoreV2 | LegacyKeyStore | null {
   if (!existsSync(filePath)) return null;
   const raw = readFileSync(filePath, 'utf-8');
-  const data = JSON.parse(raw) as unknown;
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new KeystoreError(`Keystore file is corrupted: ${filePath}`);
+  }
 
   if (isLegacyKeyStore(data)) {
     return data;

--- a/tests/panoptes.test.ts
+++ b/tests/panoptes.test.ts
@@ -5,12 +5,12 @@ import { PanoptesClient } from '../src/panoptes';
 vi.mock('axios');
 const mockGet = vi.fn();
 const mockPost = vi.fn();
-vi.mocked(axios.create).mockReturnValue({ get: mockGet, post: mockPost } as any);
+vi.mocked(axios.create).mockReturnValue({ get: mockGet, post: mockPost } as unknown as ReturnType<typeof axios.create>);
 
 describe('PanoptesClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(axios.create).mockReturnValue({ get: mockGet, post: mockPost } as any);
+    vi.mocked(axios.create).mockReturnValue({ get: mockGet, post: mockPost } as unknown as ReturnType<typeof axios.create>);
   });
 
   describe('constructor', () => {


### PR DESCRIPTION
## Summary
- Guard `--no-password` flag against V2 encrypted keystore overwrite — prevents silent data loss when encrypted keys exist
- Add `JSON.parse` error handling in `loadKeyStore` — throws `KeystoreError` on corrupted keystore file instead of raw crash
- Discriminate `getTx` errors: `RpcError` (tx not found) returns `null` for normal polling, infrastructure errors (network down, timeout) rethrow — prevents `waitForTx` from silently polling for 30s on infra failures
- Read CLI version from `package.json` dynamically instead of hardcoded `0.3.0`
- Fix lint warning: replace `as any` with `as unknown as ReturnType<typeof axios.create>` in panoptes test

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npx vitest run` — 182/182 passed
- [x] `npm run build` — ESM + CJS + DTS success