### PR TITLE
fix: add pagination support for cosmos REST queries

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -20,7 +20,10 @@ import {
 } from '../src/keystore.js';
 import type { KeyStoreV2, LegacyKeyStore, EncryptedKey } from '../src/types.js';
 
-const __cli_dirname = dirname(fileURLToPath(import.meta.url));
+// __dirname is available in CJS (tsup output), import.meta.url in ESM
+const __cli_dirname = typeof __dirname !== 'undefined'
+  ? __dirname
+  : dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__cli_dirname, '..', 'package.json'), 'utf-8')) as { version: string };
 
 const CONFIG_DIR = join(homedir(), '.republic-sdk');

--- a/src/client.ts
+++ b/src/client.ts
@@ -89,6 +89,39 @@ export class RepublicClient {
     }, this.retryOpts);
   }
 
+  /** REST GET with automatic pagination for Cosmos SDK list endpoints */
+  private async restGetPaginated<T>(
+    path: string,
+    itemsKey: string,
+    options?: { limit?: number; maxPages?: number },
+  ): Promise<T[]> {
+    const limit = options?.limit ?? 100;
+    const maxPages = options?.maxPages ?? 50;
+    const all: T[] = [];
+    let nextKey: string | null = null;
+    let page = 0;
+
+    do {
+      if (page >= maxPages) break;
+      const separator = path.includes('?') ? '&' : '?';
+      const paginationQuery = nextKey
+        ? `${separator}pagination.limit=${limit}&pagination.key=${encodeURIComponent(nextKey)}`
+        : `${separator}pagination.limit=${limit}`;
+
+      const data = await this.restGet<Record<string, unknown>>(
+        `${path}${paginationQuery}`,
+      );
+      const items = (data[itemsKey] || []) as T[];
+      all.push(...items);
+
+      const pagination = data.pagination as { next_key?: string } | undefined;
+      nextKey = pagination?.next_key ?? null;
+      page++;
+    } while (nextKey);
+
+    return all;
+  }
+
   /** Query node status */
   async getStatus(): Promise<NodeStatus> {
     const result = await this.rpcCall<{
@@ -343,12 +376,13 @@ export class RepublicClient {
   ): Promise<Validator[]> {
     const query = status ? `?status=${status}` : '';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data = await this.restGet<any>(
+    const raw = await this.restGetPaginated<any>(
       `/cosmos/staking/v1beta1/validators${query}`,
+      'validators',
     );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (data.validators || []).map((v: any) => ({
+    return raw.map((v: any) => ({
       operatorAddress: v.operator_address,
       moniker: v.description?.moniker || '',
       status: v.status,
@@ -381,12 +415,13 @@ export class RepublicClient {
   async getDelegations(delegatorAddress: string): Promise<Delegation[]> {
     validateBech32Address(delegatorAddress, this.config.addressPrefix);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data = await this.restGet<any>(
+    const raw = await this.restGetPaginated<any>(
       `/cosmos/staking/v1beta1/delegations/${encodeURIComponent(delegatorAddress)}`,
+      'delegation_responses',
     );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (data.delegation_responses || []).map((d: any) => ({
+    return raw.map((d: any) => ({
       delegatorAddress: d.delegation?.delegator_address,
       validatorAddress: d.delegation?.validator_address,
       shares: d.delegation?.shares || '0',
@@ -419,12 +454,13 @@ export class RepublicClient {
   async getRewards(delegatorAddress: string): Promise<Reward[]> {
     validateBech32Address(delegatorAddress, this.config.addressPrefix);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data = await this.restGet<any>(
+    const raw = await this.restGetPaginated<any>(
       `/cosmos/distribution/v1beta1/delegators/${encodeURIComponent(delegatorAddress)}/rewards`,
+      'rewards',
     );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (data.rewards || []).map((r: any) => ({
+    return raw.map((r: any) => ({
       validatorAddress: r.validator_address,
       reward: r.reward || [],
     })) as Reward[];
@@ -451,12 +487,13 @@ export class RepublicClient {
   async getProposals(status?: string): Promise<Proposal[]> {
     const query = status ? `?proposal_status=${status}` : '';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data = await this.restGet<any>(
+    const raw = await this.restGetPaginated<any>(
       `/cosmos/gov/v1beta1/proposals${query}`,
+      'proposals',
     );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (data.proposals || []).map((p: any) => ({
+    return raw.map((p: any) => ({
       proposalId: p.proposal_id || p.id,
       title: p.content?.title || p.title || '',
       status: p.status,

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -218,7 +218,7 @@ describe('RepublicClient', () => {
   });
 
   describe('getValidators', () => {
-    it('should parse validator list', async () => {
+    it('should parse validator list (single page)', async () => {
       mockRestGet.mockResolvedValueOnce({
         data: {
           validators: [
@@ -231,6 +231,7 @@ describe('RepublicClient', () => {
               jailed: false,
             },
           ],
+          pagination: { next_key: null, total: '1' },
         },
       });
 
@@ -245,16 +246,45 @@ describe('RepublicClient', () => {
     });
 
     it('should return empty array when no validators', async () => {
-      mockRestGet.mockResolvedValueOnce({ data: { validators: [] } });
+      mockRestGet.mockResolvedValueOnce({ data: { validators: [], pagination: { next_key: null } } });
 
       const client = new RepublicClient(undefined, { retryOptions: { maxRetries: 0 } });
       const validators = await client.getValidators();
       expect(validators).toHaveLength(0);
     });
+
+    it('should paginate across multiple pages', async () => {
+      mockRestGet
+        .mockResolvedValueOnce({
+          data: {
+            validators: [
+              { operator_address: 'raivaloper1a', description: { moniker: 'A' }, status: 'BOND_STATUS_BONDED', tokens: '100', commission: { commission_rates: { rate: '0.1' } }, jailed: false },
+            ],
+            pagination: { next_key: 'page2key', total: '2' },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            validators: [
+              { operator_address: 'raivaloper1b', description: { moniker: 'B' }, status: 'BOND_STATUS_UNBONDED', tokens: '200', commission: { commission_rates: { rate: '0.05' } }, jailed: true },
+            ],
+            pagination: { next_key: null, total: '2' },
+          },
+        });
+
+      const client = new RepublicClient(undefined, { retryOptions: { maxRetries: 0 } });
+      const validators = await client.getValidators();
+
+      expect(validators).toHaveLength(2);
+      expect(validators[0].operatorAddress).toBe('raivaloper1a');
+      expect(validators[1].operatorAddress).toBe('raivaloper1b');
+      expect(validators[1].jailed).toBe(true);
+      expect(mockRestGet).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('getDelegations', () => {
-    it('should parse delegation responses', async () => {
+    it('should parse delegation responses (single page)', async () => {
       mockRestGet.mockResolvedValueOnce({
         data: {
           delegation_responses: [
@@ -267,6 +297,7 @@ describe('RepublicClient', () => {
               balance: { denom: 'arai', amount: '1000000000000000000' },
             },
           ],
+          pagination: { next_key: null },
         },
       });
 
@@ -278,10 +309,36 @@ describe('RepublicClient', () => {
       expect(delegations[0].validatorAddress).toBe('raivaloper12rfm0s7qu0v8mwmx54uepea3kx8d2m6v30x9ys');
       expect(delegations[0].balance.amount).toBe('1000000000000000000');
     });
+
+    it('should paginate across multiple pages', async () => {
+      mockRestGet
+        .mockResolvedValueOnce({
+          data: {
+            delegation_responses: [
+              { delegation: { delegator_address: 'rai1a', validator_address: 'raivaloper1x', shares: '100' }, balance: { denom: 'arai', amount: '100' } },
+            ],
+            pagination: { next_key: 'delpage2' },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            delegation_responses: [
+              { delegation: { delegator_address: 'rai1a', validator_address: 'raivaloper1y', shares: '200' }, balance: { denom: 'arai', amount: '200' } },
+            ],
+            pagination: { next_key: null },
+          },
+        });
+
+      const client = new RepublicClient(undefined, { retryOptions: { maxRetries: 0 } });
+      const delegations = await client.getDelegations('rai12rfm0s7qu0v8mwmx54uepea3kx8d2m6vk6xc0x');
+
+      expect(delegations).toHaveLength(2);
+      expect(mockRestGet).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('getRewards', () => {
-    it('should parse rewards', async () => {
+    it('should parse rewards (single page)', async () => {
       mockRestGet.mockResolvedValueOnce({
         data: {
           rewards: [
@@ -290,6 +347,7 @@ describe('RepublicClient', () => {
               reward: [{ denom: 'arai', amount: '500000000000000000' }],
             },
           ],
+          pagination: { next_key: null },
         },
       });
 
@@ -300,10 +358,34 @@ describe('RepublicClient', () => {
       expect(rewards[0].validatorAddress).toBe('raivaloper12rfm0s7qu0v8mwmx54uepea3kx8d2m6v30x9ys');
       expect(rewards[0].reward[0].amount).toBe('500000000000000000');
     });
+
+    it('should paginate across multiple pages', async () => {
+      mockRestGet
+        .mockResolvedValueOnce({
+          data: {
+            rewards: [{ validator_address: 'raivaloper1x', reward: [{ denom: 'arai', amount: '100' }] }],
+            pagination: { next_key: 'rwdpage2' },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            rewards: [{ validator_address: 'raivaloper1y', reward: [{ denom: 'arai', amount: '200' }] }],
+            pagination: { next_key: null },
+          },
+        });
+
+      const client = new RepublicClient(undefined, { retryOptions: { maxRetries: 0 } });
+      const rewards = await client.getRewards('rai12rfm0s7qu0v8mwmx54uepea3kx8d2m6vk6xc0x');
+
+      expect(rewards).toHaveLength(2);
+      expect(rewards[0].validatorAddress).toBe('raivaloper1x');
+      expect(rewards[1].validatorAddress).toBe('raivaloper1y');
+      expect(mockRestGet).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('getProposals', () => {
-    it('should parse proposals', async () => {
+    it('should parse proposals (single page)', async () => {
       mockRestGet.mockResolvedValueOnce({
         data: {
           proposals: [
@@ -314,6 +396,7 @@ describe('RepublicClient', () => {
               voting_end_time: '2026-04-01T00:00:00Z',
             },
           ],
+          pagination: { next_key: null },
         },
       });
 
@@ -324,6 +407,30 @@ describe('RepublicClient', () => {
       expect(proposals[0].proposalId).toBe('1');
       expect(proposals[0].title).toBe('Test Proposal');
       expect(proposals[0].status).toBe('PROPOSAL_STATUS_VOTING_PERIOD');
+    });
+
+    it('should paginate across multiple pages', async () => {
+      mockRestGet
+        .mockResolvedValueOnce({
+          data: {
+            proposals: [{ proposal_id: '1', content: { title: 'Prop 1' }, status: 'PROPOSAL_STATUS_PASSED', voting_end_time: '' }],
+            pagination: { next_key: 'proppage2' },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            proposals: [{ proposal_id: '2', content: { title: 'Prop 2' }, status: 'PROPOSAL_STATUS_VOTING_PERIOD', voting_end_time: '' }],
+            pagination: { next_key: null },
+          },
+        });
+
+      const client = new RepublicClient(undefined, { retryOptions: { maxRetries: 0 } });
+      const proposals = await client.getProposals();
+
+      expect(proposals).toHaveLength(2);
+      expect(proposals[0].proposalId).toBe('1');
+      expect(proposals[1].proposalId).toBe('2');
+      expect(mockRestGet).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add generic `restGetPaginated()` helper to `RepublicClient` that automatically traverses Cosmos SDK `pagination.next_key`
- Update `getValidators()`, `getDelegations()`, `getRewards()`, `getProposals()` to use paginated fetching (backward compatible — no API signature changes)
- Fix CLI CJS crash: `import.meta.url` is undefined in CJS output, replaced with `__dirname` fallback

## Context
Cosmos SDK REST endpoints return max 100 items per page by default. The chain has 660+ validators but SDK consumers only saw the first ~100. This affected Panoptes and any other SDK user.

## Test plan
- [x] Existing 182 tests still pass (mock responses updated with pagination field)
- [x] 4 new multi-page pagination tests (one per endpoint)
- [x] CLI runtime verified: `node dist/cli.cjs --version` returns `0.3.4`
- [x] Lint clean, build clean